### PR TITLE
Cache invalidation using tags doesn't always work for libmemcached when one Memcache server isn't available

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,5 +32,6 @@
         <const name="ZEND_CACHE_TAGGING_BACKEND_MEMCACHED1_HOST" value="localhost"/>
         <const name="ZEND_CACHE_TAGGING_BACKEND_MEMCACHED2_PORT" value="35112"/>
         <const name="ZEND_CACHE_TAGGING_BACKEND_MEMCACHED2_HOST" value="localhost"/>
+        <const name="ZEND_CACHE_TAGGING_BACKEND_MEMCACHED_INVALID_PORT" value="35113"/>
     </php>
 </phpunit>

--- a/src/InterNations/Component/Caching/Zend/MemcacheTaggingBackend.php
+++ b/src/InterNations/Component/Caching/Zend/MemcacheTaggingBackend.php
@@ -24,7 +24,7 @@ class MemcacheTaggingBackend extends BaseMemcachedBackend
         return $this->_memcache;
     }
 
-    protected function loadTagRevisions(array $tags = [])
+    public function loadTagRevisions(array $tags = [])
     {
         return $this->_memcache->get($tags);
     }

--- a/src/InterNations/Component/Caching/Zend/MemcacheTaggingTrait.php
+++ b/src/InterNations/Component/Caching/Zend/MemcacheTaggingTrait.php
@@ -135,5 +135,5 @@ trait MemcacheTaggingTrait
         return parent::save($tags, $this->createTagsRelationId($id), [], $specificLifetime);
     }
 
-    abstract protected function loadTagRevisions(array $tags = []);
+    abstract public function loadTagRevisions(array $tags = []);
 }

--- a/tests/InterNations/Component/Caching/Zend/Integration/LibmemcachedIntegrationTest.php
+++ b/tests/InterNations/Component/Caching/Zend/Integration/LibmemcachedIntegrationTest.php
@@ -23,4 +23,29 @@ class LibmemcachedIntegrationTest extends AbstractIntegrationTest
         );
         $this->backend = new LibmemcachedTaggingBackend($this->memcache);
     }
+
+    public function provideBackendsWithOnlyOneServer()
+    {
+        $backends = [];
+
+        $memcache = new Memcached();
+        $memcache->addServers(
+            [
+                [ZEND_CACHE_TAGGING_BACKEND_MEMCACHED1_HOST, (int) ZEND_CACHE_TAGGING_BACKEND_MEMCACHED1_PORT],
+                [ZEND_CACHE_TAGGING_BACKEND_MEMCACHED2_HOST, (int) ZEND_CACHE_TAGGING_BACKEND_MEMCACHED_INVALID_PORT],
+            ]
+        );
+        $backends[] = [new LibmemcachedTaggingBackend($memcache)];
+
+        $memcache = new Memcached();
+        $memcache->addServers(
+            [
+                [ZEND_CACHE_TAGGING_BACKEND_MEMCACHED1_HOST, (int) ZEND_CACHE_TAGGING_BACKEND_MEMCACHED_INVALID_PORT],
+                [ZEND_CACHE_TAGGING_BACKEND_MEMCACHED2_HOST, (int) ZEND_CACHE_TAGGING_BACKEND_MEMCACHED2_PORT],
+            ]
+        );
+        $backends[] = [new LibmemcachedTaggingBackend($memcache)];
+
+        return $backends;
+    }
 }

--- a/tests/InterNations/Component/Caching/Zend/Integration/MemcacheIntegrationTest.php
+++ b/tests/InterNations/Component/Caching/Zend/Integration/MemcacheIntegrationTest.php
@@ -23,4 +23,32 @@ class MemcacheIntegrationTest extends AbstractIntegrationTest
         );
         $this->backend = new MemcacheTaggingBackend($this->memcache);
     }
-}
+
+    public function provideBackendsWithOnlyOneServer()
+    {
+        $backends = [];
+
+        $memcache = new Memcache();
+        $memcache->addServer(
+            ZEND_CACHE_TAGGING_BACKEND_MEMCACHED1_HOST,
+            (int) ZEND_CACHE_TAGGING_BACKEND_MEMCACHED1_PORT
+        );
+        $memcache->addServer(
+            ZEND_CACHE_TAGGING_BACKEND_MEMCACHED2_HOST,
+            (int) ZEND_CACHE_TAGGING_BACKEND_MEMCACHED_INVALID_PORT
+        );
+        $backends[] = [new MemcacheTaggingBackend($memcache)];
+
+        $memcache = new Memcache();
+        $memcache->addServer(
+            ZEND_CACHE_TAGGING_BACKEND_MEMCACHED1_HOST,
+            (int) ZEND_CACHE_TAGGING_BACKEND_MEMCACHED_INVALID_PORT
+        );
+        $memcache->addServer(
+            ZEND_CACHE_TAGGING_BACKEND_MEMCACHED2_HOST,
+            (int) ZEND_CACHE_TAGGING_BACKEND_MEMCACHED2_PORT
+        );
+        $backends[] = [new MemcacheTaggingBackend($memcache)];
+
+        return $backends;
+    }}


### PR DESCRIPTION
When using the  `LibmemcachedTaggingBackend` with two Memcache servers using the default configuration, the invalidation using the tags might not always work. This is because the tag(s) might be stored on the unresponsive server. There it cannot be fetched and the backend is trying to create new tag with value 1. If this was the value before the call to `clean` was made, the backend will assume that the actual content it fetches later on based on the tag values is the correct cached item and will return it therefore leaving the call to `clean` without effect.

I'll attach a PR showing the problem in a unit test since I'm not sure how this can be fixed or if it might even be a bug in php5-memcached/libmemcached not removing unresponsible servers from the pool.
